### PR TITLE
perf optimizations

### DIFF
--- a/SHA256CUDA/main.cu
+++ b/SHA256CUDA/main.cu
@@ -17,7 +17,7 @@
 #include "sha256.cuh"
 
 #define SHOW_INTERVAL_MS 2000
-#define ITERATIONS_PER_KERNEL 100
+#define ITERATIONS_PER_KERNEL 256
 #define BLOCK_SIZE 256
 #define NUMBLOCKS 163834u
 #define IDX_MULTIPLIER (NUMBLOCKS * BLOCK_SIZE * ITERATIONS_PER_KERNEL)
@@ -81,11 +81,9 @@ __constant__ uint64_t total_nonces = IDX_MULTIPLIER;
 __constant__ unsigned char constant_bytes[4] = { 0xD8, 0x79, 0x9f, 0x50 };
 __global__ void sha256_kernel(uint64_t* out_nonce_low, uint64_t* out_nonce_high, unsigned char* out_found_hash, int* out_found, const char* in_input_string, size_t in_input_string_size, uint8_t difficulty, uint64_t nonce_offset_low, uint64_t nonce_offset_high) {
     __shared__ SHA256_CTX shared_ctx[BLOCK_SIZE];
-
     uint64_t nonce_low;
     uint64_t nonce_high;
 
-    unsigned char nonce[16];
     unsigned char sha[32];
 
     for (uint64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -99,19 +97,25 @@ __global__ void sha256_kernel(uint64_t* out_nonce_low, uint64_t* out_nonce_high,
             nonce_high++;
         }
 
-        nonce_to_bytes(nonce_low, nonce_high, nonce);
+        // Initialize SHA256 context
+        sha256_init(&shared_ctx[threadIdx.x]);
 
-        {
-            sha256_init(&shared_ctx[threadIdx.x]);
-            sha256_update(&shared_ctx[threadIdx.x], constant_bytes, 4);
-            sha256_update(&shared_ctx[threadIdx.x], nonce, 16);
-            sha256_update(&shared_ctx[threadIdx.x], (unsigned char*)in_input_string, in_input_string_size);
-            sha256_final(&shared_ctx[threadIdx.x], sha);
+        // Directly write constant_bytes and nonce to ctx.data
+        shared_ctx[threadIdx.x].data[0] = constant_bytes[0];
+        shared_ctx[threadIdx.x].data[1] = constant_bytes[1];
+        shared_ctx[threadIdx.x].data[2] = constant_bytes[2];
+        shared_ctx[threadIdx.x].data[3] = constant_bytes[3];
+        nonce_to_bytes(nonce_low, nonce_high, shared_ctx[threadIdx.x].data + 4);
 
-            sha256_init(&shared_ctx[threadIdx.x]);
-            sha256_update(&shared_ctx[threadIdx.x], sha, 32);
-            sha256_final(&shared_ctx[threadIdx.x], sha);
-        }
+        // Adjust data length accordingly
+        shared_ctx[threadIdx.x].datalen = 20; // 4 bytes for constant_bytes + 16 bytes for nonce
+
+        sha256_update(&shared_ctx[threadIdx.x], (unsigned char*)in_input_string, in_input_string_size);
+        sha256_final(&shared_ctx[threadIdx.x], sha);
+
+        sha256_init(&shared_ctx[threadIdx.x]);
+        sha256_update(&shared_ctx[threadIdx.x], sha, 32);
+        sha256_final(&shared_ctx[threadIdx.x], sha);
 
         if (checkZeroPadding(sha, difficulty) && atomicExch(out_found, 1) == 0) {
             memcpy(out_found_hash, sha, 32);


### PR DESCRIPTION
6% gain or so for me

mostly just reuses some of the data array in the sha256 context instead of storing things in intermediate arrays

also reduced the size of sha256 context, which ended up giving it better alignment too, so the padding that was in it before can be removed

then a couple extra loop unrolls help a tiny bit